### PR TITLE
[FEAT/DESIGN] 영상 길이 노출, 영상 시작 시간 입력 추가

### DIFF
--- a/src/Pages/Run/AddReserv.js
+++ b/src/Pages/Run/AddReserv.js
@@ -1,3 +1,11 @@
+import { faDashcube } from "@fortawesome/free-brands-svg-icons";
+import { faColonSign } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  HorizontalRule,
+  HorizontalRuleRounded,
+  Rule,
+} from "@mui/icons-material";
 import axios from "axios";
 import React, { useState } from "react";
 import styled from "styled-components";
@@ -6,7 +14,7 @@ import Add_Reserv from "../../Assets/Add_Reserv.png";
 import Temp from "../../Assets/Temp_gif.png";
 import preURL from "../../preURL/preURL";
 import StyledBtn from "../../Style/StyledBtn";
-import { StyledDiv } from "../../Style/StyledDiv";
+import { StyledDiv, StyledDivRow } from "../../Style/StyledDiv";
 
 const AddReserv = () => {
   const [title, setTitle] = useState("");
@@ -18,6 +26,11 @@ const AddReserv = () => {
   const [rItem, setRItem] = useState({});
   const [rTitle, setRTitle] = useState("");
 
+  const [date, setDate] = useState("00");
+  const [hour1, setHour1] = useState("0");
+  const [hour2, setHour2] = useState("0");
+  const [min1, setmin1] = useState("0");
+
   const WhiteBoxStyle = {
     borderStyle: "none",
     backgroundColor: "white",
@@ -28,6 +41,16 @@ const AddReserv = () => {
     alignItems: "center",
     paddingLeft: 10,
     margin: 0,
+  };
+
+  // 제목 input 관리
+  const onChange = (e) => {
+    setTitle(e.target.value);
+    if (title.length > 0) {
+      searchTitle();
+    } else if (title.length == 0) {
+      setSResult(false);
+    }
   };
 
   // 영상 제목 조회
@@ -62,6 +85,7 @@ const AddReserv = () => {
           type="button"
           onClick={() => {
             setRTitle(item);
+            setTitle(rTitle);
             setRItem(results[i]);
             // 한 번에 작동하지 않음 <- 수정 필요
             console.log("선택된 제목의 정보 :", rItem);
@@ -74,6 +98,18 @@ const AddReserv = () => {
     );
   });
 
+  // 24시간에 대한 제약 필요(1. 십의 자리수는 2를 초과할 수 없음 2. 십의 자리가 2일 경우, 1의 자리는 4를 초과할 수 없음)
+  // 예약 시간 input 관리
+  const onChangeTime = (e) => {
+    if (e.target.name == "hour1") {
+      setHour1(e.target.value);
+    } else if (e.target.name == "hour2") {
+      setHour2(e.target.value);
+    } else if (e.target.name == "min1") {
+      setmin1(e.target.value);
+    }
+  };
+
   // 날짜 구하기
   let now = new Date();
   let year = now.getFullYear();
@@ -82,7 +118,7 @@ const AddReserv = () => {
 
   let body = {
     id: rItem.id,
-    reservationDate: `${year}-${todayMonth}-${todayDate}`,
+    reservationDate: `${year}-${todayMonth}-${date}`,
     startTime: 0,
     endTime: 0,
   };
@@ -96,15 +132,6 @@ const AddReserv = () => {
       .catch((err) => {
         console.error("⚠️ 예약 등록 ⚠️ ", err);
       });
-  };
-
-  const onChange = (e) => {
-    setTitle(e.target.value);
-    if (title.length > 0) {
-      searchTitle();
-    } else if (title.length == 0) {
-      setSResult(false);
-    }
   };
 
   return (
@@ -162,16 +189,54 @@ const AddReserv = () => {
                       오늘 ({todayMonth}/{todayDate})
                     </WhiteBoxBtn>
                     {/* 다음달로 넘어가는 경우 처리 필요 */}
-                    <WhiteBoxBtn>
+                    <WhiteBoxBtn
+                      onClick={() => {
+                        setDate(todayDate + 1);
+                      }}
+                    >
                       내일 ({todayMonth}/{todayDate + 1})
                     </WhiteBoxBtn>
-                    <WhiteBoxBtn>
+                    <WhiteBoxBtn
+                      onClick={() => {
+                        setDate(todayDate + 2);
+                      }}
+                    >
                       모레 ({todayMonth}/{todayDate + 2})
                     </WhiteBoxBtn>
                     {/* 처리 필요 */}
                   </StyledDiv>
-                  <p>영상 예약 시간</p>
-                  <p>시간 들어갈 예정</p>
+                  <p>영상 예약 시간(10분 단위로 입력 가능)</p>
+                  <StyledDivRow
+                    className="reservTime"
+                    style={{ width: 403, justifyContent: "space-between" }}
+                  >
+                    <TimeInput
+                      type="number"
+                      name="hour1"
+                      onChange={onChangeTime}
+                      value={hour1}
+                    ></TimeInput>
+                    <TimeInput
+                      type="number"
+                      name="hour2"
+                      onChange={onChangeTime}
+                      value={hour2}
+                    ></TimeInput>
+                    <Sign>:</Sign>
+                    <TimeInput
+                      type="number"
+                      name="min1"
+                      onChange={onChangeTime}
+                      value={min1}
+                    ></TimeInput>
+                    <TimeWBox>0</TimeWBox>
+                    <Sign>-</Sign>
+                    <TimeWBox></TimeWBox>
+                    <TimeWBox></TimeWBox>
+                    <Sign>:</Sign>
+                    <TimeWBox></TimeWBox>
+                    <TimeWBox></TimeWBox>
+                  </StyledDivRow>
                 </div>
               </div>
               <StyledDiv
@@ -185,7 +250,17 @@ const AddReserv = () => {
                 <img src={Temp} style={{ width: 188, height: 106 }} />
                 <div>
                   <p>총 재생 시간</p>
-                  <p>시간 들어갈 예정</p>
+                  <StyledDivRow
+                    style={{ width: 163, justifyContent: "space-between" }}
+                  >
+                    <TimeWBox style={{ width: 62 }}>
+                      {rItem.runtimeHour}
+                    </TimeWBox>
+                    <Sign>:</Sign>
+                    <TimeWBox style={{ width: 62 }}>
+                      {rItem.runtimeMin}
+                    </TimeWBox>
+                  </StyledDivRow>
                   <StyledBtn
                     style={{
                       color: "white",
@@ -257,6 +332,11 @@ const WhiteBoxBtn = styled(StyledBtn)`
   display: flex;
   justify-content: center;
   align-items: center;
+
+  &:hover {
+    background-color: #e37958;
+    color: white;
+  }
 `;
 
 const AddCatWrapper = styled.div`
@@ -272,4 +352,30 @@ const AddCat = styled(StyledBtn)`
   border-radius: 10px;
   font-weight: bold;
   background-color: ${(props) => (props.default ? "#EFE8CC" : "#E37958")};
+`;
+
+const TimeInput = styled.input`
+  justify-content: center;
+  align-items: center;
+  background-color: white;
+  height: 33px;
+  width: 31px;
+  border-radius: 8px;
+  font-weight: bold;
+`;
+
+const TimeWBox = styled(StyledDiv)`
+  justify-content: center;
+  align-items: center;
+  background-color: white;
+  height: 33px;
+  width: 31px;
+  border-style: none;
+  border-radius: 8px;
+  font-weight: bold;
+`;
+
+const Sign = styled.span`
+  font-size: 35px;
+  font-weight: bold;
 `;

--- a/src/Pages/Run/AddReserv.js
+++ b/src/Pages/Run/AddReserv.js
@@ -9,6 +9,15 @@ import StyledBtn from "../../Style/StyledBtn";
 import { StyledDiv } from "../../Style/StyledDiv";
 
 const AddReserv = () => {
+  const [title, setTitle] = useState("");
+  const [sTitle, setSTitle] = useState("");
+  const [result, setResult] = useState([]);
+  const [sResult, setSResult] = useState(false);
+  const [results, setResults] = useState([]);
+  // 검색 후, 선택된 제목
+  const [rItem, setRItem] = useState({});
+  const [rTitle, setRTitle] = useState("");
+
   const WhiteBoxStyle = {
     borderStyle: "none",
     backgroundColor: "white",
@@ -18,7 +27,52 @@ const AddReserv = () => {
     display: "flex",
     alignItems: "center",
     paddingLeft: 10,
+    margin: 0,
   };
+
+  // 영상 제목 조회
+  const searchTitle = () => {
+    axios
+      .get(preURL.preURL + `/run/reservations/title/search?q=${sTitle}`)
+      .then((res) => {
+        console.log("❕영상 제목 조회❕ ", res.data);
+        setResults(res.data);
+        let newResult = [];
+        for (let i = 0; i < results.length; i++) {
+          newResult.push(results[i].title);
+        }
+        // 한 번에 작동하지 않음 <- 수정 필요
+        setResult(newResult);
+        console.log("연관 검색어 리스트 : ", result);
+        setSResult(true);
+      })
+      .catch((err) => {
+        console.error("⚠️ 영상 제목 조회 ⚠️ ", err);
+      });
+  };
+
+  // 연관 검색어 드롭 다운 리스트
+  const ArrayData = result.map((item, i) => {
+    return (
+      <li
+        key={i}
+        style={{ listStyle: "none", backgroundColor: "white", padding: 3 }}
+      >
+        <StyledBtn
+          type="button"
+          onClick={() => {
+            setRTitle(item);
+            setRItem(results[i]);
+            // 한 번에 작동하지 않음 <- 수정 필요
+            console.log("선택된 제목의 정보 :", rItem);
+            setSResult(false);
+          }}
+        >
+          <span>{item}</span>
+        </StyledBtn>
+      </li>
+    );
+  });
 
   // 날짜 구하기
   let now = new Date();
@@ -26,15 +80,31 @@ const AddReserv = () => {
   let todayMonth = now.getMonth() + 1;
   let todayDate = now.getDate();
 
+  let body = {
+    id: rItem.id,
+    reservationDate: `${year}-${todayMonth}-${todayDate}`,
+    startTime: 0,
+    endTime: 0,
+  };
+
   const reservations = () => {
     axios
-      .post(preURL.preURL + "/run/reservations")
+      .post(preURL.preURL + "/run/reservations", body)
       .then((res) => {
         console.log("❕예약 등록❕ ", res.data);
       })
       .catch((err) => {
         console.error("⚠️ 예약 등록 ⚠️ ", err);
       });
+  };
+
+  const onChange = (e) => {
+    setTitle(e.target.value);
+    if (title.length > 0) {
+      searchTitle();
+    } else if (title.length == 0) {
+      setSResult(false);
+    }
   };
 
   return (
@@ -55,11 +125,34 @@ const AddReserv = () => {
             }}
           >
             <StyledDiv>
-              <div>
+              <div style={{ position: "relative" }}>
                 <p>영상 제목</p>
-                <input type="text" name="title" style={WhiteBoxStyle} />
+                <input
+                  type="text"
+                  name="title"
+                  onChange={onChange}
+                  value={title}
+                  style={WhiteBoxStyle}
+                />
+                {sResult ? (
+                  <ul
+                    style={{
+                      width: 393,
+                      textAlign: "start",
+                      paddingLeft: 10,
+                      zIndex: 10,
+                      backgroundColor: "white",
+                      margin: 0,
+                      position: "absolute",
+                    }}
+                  >
+                    {ArrayData}
+                  </ul>
+                ) : (
+                  <></>
+                )}
                 <p>영상 URL</p>
-                <p style={WhiteBoxStyle}>anjtlll</p>
+                <p style={WhiteBoxStyle}>{rItem.thumbnailUrl}</p>
                 <div>
                   <p>영상 예약 날짜</p>
                   <StyledDiv


### PR DESCRIPTION
## 개요 :mag:
영상 길이 노출, 영상 시작 시간 입력 추가

## 작업사항 :memo:
**AddReserv.js**
- 영상 길이 노출(선택한 영상의 크롤링된 정보)
- 영상 시작 시간 입력 추가 : 이후 디자인 수정, 시간 제한 조건 추가 필요

## 구현화면 👓
<img width="1440" alt="스크린샷 2022-07-13 오전 2 27 34" src="https://user-images.githubusercontent.com/67596636/178555788-d962fb92-1d54-4bc3-9e08-642808cb6431.png">

## 다음 PR
- [ ] 예약 등록하기(시간 선택, 등록) 기능 추가
- [ ] 타임 테이블 디자인 추가
- [ ] 타임 테이블 기능 추가