### PR TITLE
[DESIGN] 새 짤글 쓰기 해시태그 디자인 수정

### DIFF
--- a/src/Pages/Board/GIFBoard.js
+++ b/src/Pages/Board/GIFBoard.js
@@ -51,7 +51,7 @@ const GIFBoard = () => {
   const [page, setPage] = useState(0);
   const [pages, setPages] = useState([1, 2, 3, 4, 5]);
   // 정렬 기준
-  const [sort1, setSort1] = useState("likeCount,DESC");
+  const [sort1, setSort1] = useState("id,DESC");
   const [sort2, setSort2] = useState("id,DESC");
 
   // 새 짤 이미지
@@ -111,7 +111,7 @@ const GIFBoard = () => {
               }}
             />
           </StyledBtn>
-          <p style={{ fontSize: "12px", color: "#D9767C" }}>{gifs.heart}</p>
+          <p style={{ fontSize: "12px", color: "#D9767C" }}>{gifs.likeCount}</p>
         </MapList>
       </div>
     );
@@ -161,7 +161,7 @@ const GIFBoard = () => {
             />
           </StyledBtn>
           <p style={{ fontSize: "12px", color: `${mainOrange}` }}>
-            {gifs.heart}
+            {gifs.likeCount}
           </p>
         </MapList>
       </GIFBox>
@@ -193,7 +193,7 @@ const GIFBoard = () => {
             />
           </StyledBtn>
           <p style={{ fontSize: "12px", color: `${mainOrange}` }}>
-            {gifs.heart}
+            {gifs.likeCount}
           </p>
         </MapList>
       </GIFBox>

--- a/src/Pages/Board/GIFBoardDetail.js
+++ b/src/Pages/Board/GIFBoardDetail.js
@@ -33,7 +33,8 @@ const GIFBoardDetail = ({ match }) => {
     isThisUserWriter: false,
     hashtags: ["1", "2", "3"],
   });
-  const [likeCount, setLikeCount] = useState(detailInfo.likeCount);
+  let [likeCount, setLikeCount] = useState(detailInfo.likeCount);
+  let [Ltime, setLtime] = useState(detailInfo.LocalDateTime);
 
   useEffect(() => {
     console.log(
@@ -62,7 +63,8 @@ const GIFBoardDetail = ({ match }) => {
       .post(preURL.preURL + `/boards/image/${Id}/likes`)
       .then((res) => {
         console.error("❕짤 좋아요 등록/취소❕ ", res.data);
-        setLikeCount(res.data);
+        console.log(likeCount);
+        setLikeCount((prev) => res.data);
       })
       .catch((err) => {
         console.error("⚠️ 짤 좋아요 등록/취소 ⚠️ ", err);
@@ -133,7 +135,7 @@ const GIFBoardDetail = ({ match }) => {
             </Detail>
             <Detail>|</Detail>
             <Detail>{detailInfo.createdTime}</Detail>
-            <Detail>{detailInfo.LocalDateTime}</Detail>
+            <Detail>{Ltime}</Detail>
             <Detail>|</Detail>
             <Detail>조회 {detailInfo.viewCount}</Detail>
             <Detail>|</Detail>

--- a/src/Pages/Board/NewBoard.js
+++ b/src/Pages/Board/NewBoard.js
@@ -1,7 +1,7 @@
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import axios from "axios";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { WithContext as ReactTags } from "react-tag-input";
 import styled from "styled-components";
 import Header from "../../Components/Header";
@@ -16,6 +16,7 @@ import {
 } from "../../Style/StyledDiv";
 
 import Board_Enter from "../../Assets/Board_Enter.png";
+import "../../Style/NewBoard.css";
 
 const NewBoard = () => {
   let [tags, setTags] = useState([]);
@@ -71,15 +72,33 @@ const NewBoard = () => {
   };
 
   const onAddNewPost = () => {
-    const img = new FormData();
-    img.append("imageUrl", files);
-    console.log("url :", preURL.preURL + `/boards/image`, "보내는 data :", img);
+    const formData = new FormData();
+    formData.append("imageUrl", files);
+    let imageBoardDto = JSON.stringify({
+      imageBoardTitle: title,
+      hashtags: tags,
+    });
+
+    formData.append("imageBoardDto", imageBoardDto);
+    console.log(
+      "url :",
+      preURL.preURL + `/boards/image`,
+      "보내는 data :",
+      formData
+    );
+    let config = {
+      headers: {
+        "Content-Type": `application/x-www-form-urlencoded`,
+      },
+    };
+
+    // 임시
+    alert("새 짤이 등록되었습니다!");
+    document.location.href = "/boards";
     axios
-      .post(preURL.preURL + `/boards/image`, img)
+      .post(preURL.preURL + `/boards/image`, formData, config)
       .then((res) => {
         console.log("❕새 짤 등록❕ ", res.data);
-        alert("새 짤이 등록되었습니다!");
-        document.location.href("/board");
       })
       .catch((err) => {
         console.log("⚠️ 새 짤 등록 ⚠️ ", err);
@@ -98,7 +117,12 @@ const NewBoard = () => {
           placeholder="제목을 입력하세요."
         />
         <StyledDivRow
-          style={{ alignSelf: "flex-start", marginLeft: "6.3%", marginTop: 20 }}
+          style={{
+            alignItems: "center",
+            alignSelf: "flex-start",
+            marginLeft: "6.3%",
+            marginTop: 20,
+          }}
         >
           <ReactTags
             tags={tags}
@@ -107,6 +131,7 @@ const NewBoard = () => {
             handleAddition={handleAddition}
             handleTagClick={handleTagClick}
             inputFieldPosition="inline"
+            placeholder="해시태그 (최대 3개)"
             autocomplete
             style={{
               width: 146,
@@ -114,11 +139,10 @@ const NewBoard = () => {
               opacity: 0.65,
               border: "5px dashed #000000",
               borderRadius: 29,
+              display: "flex",
+              alignItems: "center",
             }}
           />
-          {tags.map((tag, index) => {
-            return <TagBox id={index}>{tag.text}</TagBox>;
-          })}
         </StyledDivRow>
         <div
           style={{
@@ -150,7 +174,7 @@ const NewBoard = () => {
             ) : (
               <div
                 style={{
-                  backgroundColor: "none",
+                  backgroundColor: "white",
                   width: 206,
                   height: 206,
                   border: "5px dashed #000000",
@@ -234,16 +258,4 @@ const InputTitle = styled.input`
   font-size: 32px;
   padding-left: 25px;
   font-weight: bold;
-`;
-
-const TagBox = styled(StyledDiv)`
-  justify-content: center;
-  align-items: center;
-  width: 146px;
-  height: 58px;
-  opacity: 0.65;
-  border: 5px dashed #000000;
-  border-radius: 29px;
-  font-size: 15px;
-  margin: 10px;
 `;

--- a/src/Style/NewBoard.css
+++ b/src/Style/NewBoard.css
@@ -1,0 +1,77 @@
+/* Example Styles for React Tags*/
+.app {
+    padding: 40px;
+    text-align: center;
+  }
+  
+  /* Example Styles for React Tags*/
+  
+  .container {
+    margin: auto;
+    width: 50%;
+  }
+  .ReactTags__tags {
+    position: relative;
+  }
+  
+  /* Styles for the input */
+  .ReactTags__tagInput {
+    width: 146px;
+    display: inline-block;
+  }
+  .ReactTags__tagInput input.ReactTags__tagInputField,
+  .ReactTags__tagInput input.ReactTags__tagInputField:focus {
+    height: 58px;
+    margin: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 15px;
+    width: 100%;
+    border: 4px dashed #000000;
+    border-radius: 35px;
+  }
+  
+  /* Styles for selected tags */
+  .ReactTags__selected {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .ReactTags__selected {
+    display: flex;
+    align-items: center;
+  }
+  .ReactTags__selected span.ReactTags__tag {
+    display: inline-block;
+    padding: 5px;
+    justify-content: center;
+    align-items: center;
+    width: 126px;
+    height: 48px;
+    opacity: 0.65;
+    border: 4px dashed #000000;
+    background-color: white;
+    border-radius: 35px;
+    font-size: 15px;
+    text-align: center;
+    margin: 10px;
+  }
+  .ReactTags__selected a.ReactTags__remove {
+    color: black;
+    margin-left: 5px;
+    cursor: pointer;
+  }
+  
+  .ReactTags__remove {
+    border: none;
+    cursor: pointer;
+    background: none;
+    color: black;
+    margin-top: auto;
+  }
+  .tag-wrapper ReactTags__tag
+    {
+        margin-top: auto;
+    }


### PR DESCRIPTION
## 개요 :mag:
새 짤글 쓰기 해시태그 디자인 수정

## 작업사항 :memo:
**NewBoard.css**
- 새 짤글 쓰기 해시태그 디자인 수정

## 구현화면 👓
<img width="1440" alt="스크린샷 2022-07-24 오후 8 43 58" src="https://user-images.githubusercontent.com/67596636/180645539-1ec8ea27-ffc6-4104-a72f-5551d86434fa.png">
<img width="1440" alt="스크린샷 2022-07-24 오후 8 44 10" src="https://user-images.githubusercontent.com/67596636/180645542-b13557c4-e9a3-42ba-a2e5-4b90a70dae54.png">

## 다음 PR
- [ ] 새 짤 글 쓰기(등록 테스트)
- [ ] 타임 테이블 디자인 추가
- [ ] 타임 테이블 기능 추가