### PR TITLE
[FEAT] 마이페이지 내용 불러오기 & 전체 영상 페이지 url 변경

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -48,8 +48,8 @@ const App = () => {
         <Route path="/search" element={<Search />} />
         {/* Video */}
         <Route path="/addvideo" element={<AddNewVideo />} />
-        <Route path="/videolist" element={<AllVideo />} />
-        <Route path="/videolist/:id" element={<VideoDetail />} />
+        <Route path="/video" element={<AllVideo />} />
+        <Route path="/video/:id" element={<VideoDetail />} />
         {/* Playlist */}
         <Route path="/playlist" element={<AllPlaylist />} />
         <Route path="/playlist/:id" element={<PlaylistDetail />} />

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -81,7 +81,7 @@ const Header = ({ darkMode }) => {
       <RightWrapper>
         {/* 카테고리 링크 */}
         <StyledDivRow style={{ width: 540, justifyContent: "space-between" }}>
-          <StyledLink to="/videolist">
+          <StyledLink to="/video">
             <Category>영상</Category>
           </StyledLink>
           <StyledLink to="/playlist">

--- a/src/Components/Mypage/MyComment.js
+++ b/src/Components/Mypage/MyComment.js
@@ -1,0 +1,35 @@
+import React from "react";
+import {useNavigate} from "react-router-dom";
+import {timeStamp} from "../TimeStamp";
+import styled from "styled-components";
+
+
+const MyComment = ({comment}) => {
+  const navigate = useNavigate();
+
+  return (
+      <Wrapper onClick={() => navigate(`/${comment.boardType}/${comment.boardId}`)}>
+        <Content>{comment.content}</Content>
+        <Info>{comment.boardTitle}</Info>
+        <Info> | </Info>
+        <Info>{timeStamp(comment.createdTime)}</Info>
+      </Wrapper>
+  )
+}
+
+export default MyComment;
+
+const Wrapper = styled.div`
+  cursor: pointer;
+`
+
+const Content = styled.p`
+  font-size: 18px;
+  line-height: 20px;
+  margin-bottom: 0;
+`
+
+const Info = styled.span`
+  font-size: 12px;
+  line-height: 14px;
+`

--- a/src/Components/Mypage/MyVideo.js
+++ b/src/Components/Mypage/MyVideo.js
@@ -16,12 +16,12 @@ const MyVideo = ({video}) => {
 
   return (
       <OneVideoWrapper>
-        <VideoContainer onClick={()=>navigate(`/videolist/${videoId}`)}>
+        <VideoContainer onClick={()=>navigate(`/video/${videoId}`)}>
           <img src={video.thumbnailUrl} alt="썸네일" />
         </VideoContainer>
         <div>
           <VideoInfo>
-            <span id="title" onClick={()=>navigate(`/videolist/${videoId}`)}>
+            <span id="title" onClick={()=>navigate(`/video/${videoId}`)}>
               {video.title}
             </span>
             <div id="info-right">

--- a/src/Components/Mypage/Pagination.js
+++ b/src/Components/Mypage/Pagination.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import StyledBtn from "../../Style/StyledBtn";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faCaretLeft, faCaretRight} from "@fortawesome/free-solid-svg-icons";
@@ -8,7 +8,12 @@ import {light} from "../../Style/Color";
 const Pagination = ({page, setPage, totalPageCount}) => {
 
   const [showGoLeftPages, setShowGoLeftPages] = useState(false);
-  const [showGoRightPages, setShowGoRightPages] = useState(totalPageCount !== 1);
+  const [showGoRightPages, setShowGoRightPages] = useState(true);
+
+  useEffect(() => {
+    setShowGoRightPages(totalPageCount > 1);
+    // console.log(totalPageCount);
+  },[totalPageCount]);
 
 
   // 페이지 넘기기

--- a/src/Components/Video/OneVideo.js
+++ b/src/Components/Video/OneVideo.js
@@ -34,12 +34,12 @@ const OneVideo = ({video}) => {
 
   return (
       <OneVideoWrapper>
-        <VideoContainer onClick={()=>navigate(`/videolist/${videoId}`)}>
+        <VideoContainer onClick={()=>navigate(`/video/${videoId}`)}>
           <img src={video.thumbnailUrl} alt="썸네일" />
         </VideoContainer>
         <div>
           <VideoInfo>
-              <span id="title" onClick={()=>navigate(`/videolist/${videoId}`)}>
+              <span id="title" onClick={()=>navigate(`/video/${videoId}`)}>
                 {video.title}
               </span>
             <div id="info-right">

--- a/src/Pages/Member/MyPage.js
+++ b/src/Pages/Member/MyPage.js
@@ -1,6 +1,10 @@
-import React, {useState} from "react";
+import React, {useContext, useEffect, useState} from "react";
 import {useNavigate} from "react-router-dom";
+import axios from "axios";
+import {preURL} from "../../preURL/preURL";
+import {UserContext} from "../../_contextAPI/UserContext";
 // Component
+import Token from "../../Components/Token";
 import Header from "../../Components/Header";
 import MyVideo from "../../Components/Mypage/MyVideo";
 import MyPly from "../../Components/Mypage/MyPly";
@@ -24,54 +28,124 @@ import {VideoList} from "../../Style/Video";
 // Assets
 import GotoPly from "../../Assets/Mypage_GotoSavedply.png";
 import Eye from "../../Assets/Mypage_eye1.png";
+import MyComment from "../../Components/Mypage/MyComment";
 
 
 const MyPage = () => {
   const navigate = useNavigate();
+  const token = Token();
+  const [user,setUser] = useContext(UserContext);
 
   const [profileImg, setProfileImg] = useState("https://demo.ycart.kr/shopboth_farm_max5_001/data/editor/1612/cd2f39a0598c81712450b871c218164f_1482469221_493.jpg");
   const [profileName, setProfileName] = useState("닉넴");
   const [profileEmail, setProfileEmail] = useState("이메일");
   const [videos, setVideos] = useState([
-    {id: 1, title: "영상 1", likeCount: 5, thumbnailUrl: "", isPublic: null},
-    {id: 2, title: "영상 2", likeCount: 5, thumbnailUrl: "", isPublic: null},
-    {id: 3, title: "영상 3", likeCount: 5, thumbnailUrl: "", isPublic: null},
-    {id: 4, title: "영상 4", likeCount: 5, thumbnailUrl: "", isPublic: null},
-    {id: 1, title: "영상 1", likeCount: 5, thumbnailUrl: "", isPublic: null},
-    {id: 2, title: "영상 2", likeCount: 5, thumbnailUrl: "", isPublic: null},
-    {id: 3, title: "영상 3", likeCount: 5, thumbnailUrl: "", isPublic: null},
-    {id: 4, title: "영상 4", likeCount: 5, thumbnailUrl: "", isPublic: null}
+    // {id: 1, title: "영상 1", likeCount: 5, thumbnailUrl: "", isPublic: null},
+    // {id: 2, title: "영상 2", likeCount: 5, thumbnailUrl: "", isPublic: null},
+    // {id: 3, title: "영상 3", likeCount: 5, thumbnailUrl: "", isPublic: null},
+    // {id: 4, title: "영상 4", likeCount: 5, thumbnailUrl: "", isPublic: null},
+    // {id: 1, title: "영상 1", likeCount: 5, thumbnailUrl: "", isPublic: null},
+    // {id: 2, title: "영상 2", likeCount: 5, thumbnailUrl: "", isPublic: null},
+    // {id: 3, title: "영상 3", likeCount: 5, thumbnailUrl: "", isPublic: null},
+    // {id: 4, title: "영상 4", likeCount: 5, thumbnailUrl: "", isPublic: null}
   ]);
-  const [totalVPage, setTotalVPage] = useState(3);
+  const [totalVPage, setTotalVPage] = useState(0);
   const [videosPage, setVideosPage] = useState(0);
   const [playlist, setPlaylist] = useState([
-    {id: 1, title: "플리1", titleImageUrl: "https://i.ytimg.com/vi/xhyWDLWanHE/hqdefault.jpg?s…AFwAcABBg==&rs=AOn4CLDNC541Gll7yxMs9Vcc8MWtC9gzLg", likeCount: 3, isPublic: true},
-    {id: 2, title: "플리2", titleImageUrl: "https://i.ytimg.com/vi/MRaAcIQOIIw/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLDMAXcYHT37gxseIf6CA94ICpnTuQ", likeCount: 25, isPublic: true},
-    {id: 3, title: "플리3", titleImageUrl: "https://i.ytimg.com/vi/1ktnYFMm4S0/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLBRJHJTM-_VzaapK9oCWlD8t-K8WQ", likeCount: 3, isPublic: true},
-    {id: 4, title: "플리4", titleImageUrl: "https://i.ytimg.com/vi/Q2ehBSEkAzw/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLDgtPhu8WY4xOABtcCjVo5x-hgswA", likeCount: 22, isPublic: false},
-    {id: 5, title: "플리5", titleImageUrl: "https://i.ytimg.com/vi/mKkYQ2OwYYg/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLB-2wmECn5003TmXqION-Nqcgahzw", likeCount: 30, isPublic: false},
-    {id: 6, title: "플리6", titleImageUrl: "https://i.ytimg.com/vi/iiIcTPoIoZk/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLAjn_R-euhMSNKaCFjJzO89A93tAA", likeCount: 19, isPublic: false},
-    {id: 7, title: "플리7", titleImageUrl: "https://i.ytimg.com/vi/UfBxMDp7VTo/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLCJF-TybRxbbgYlWXiz2ARY6e-aHw", likeCount: 3, isPublic: false},
-    {id: 8, title: "플리8", titleImageUrl: "https://i.ytimg.com/vi/MzVRL5W4b1I/hqdefault.jpg?s…AFwAcABBg==&rs=AOn4CLDJ-2oHWJdsOn-YBOi9t52n0qepNw", likeCount: 3, isPublic: true}
+    // {id: 1, title: "플리1", titleImageUrl: "https://i.ytimg.com/vi/xhyWDLWanHE/hqdefault.jpg?s…AFwAcABBg==&rs=AOn4CLDNC541Gll7yxMs9Vcc8MWtC9gzLg", likeCount: 3, isPublic: true},
+    // {id: 2, title: "플리2", titleImageUrl: "https://i.ytimg.com/vi/MRaAcIQOIIw/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLDMAXcYHT37gxseIf6CA94ICpnTuQ", likeCount: 25, isPublic: true},
+    // {id: 3, title: "플리3", titleImageUrl: "https://i.ytimg.com/vi/1ktnYFMm4S0/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLBRJHJTM-_VzaapK9oCWlD8t-K8WQ", likeCount: 3, isPublic: true},
+    // {id: 4, title: "플리4", titleImageUrl: "https://i.ytimg.com/vi/Q2ehBSEkAzw/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLDgtPhu8WY4xOABtcCjVo5x-hgswA", likeCount: 22, isPublic: false},
+    // {id: 5, title: "플리5", titleImageUrl: "https://i.ytimg.com/vi/mKkYQ2OwYYg/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLB-2wmECn5003TmXqION-Nqcgahzw", likeCount: 30, isPublic: false},
+    // {id: 6, title: "플리6", titleImageUrl: "https://i.ytimg.com/vi/iiIcTPoIoZk/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLAjn_R-euhMSNKaCFjJzO89A93tAA", likeCount: 19, isPublic: false},
+    // {id: 7, title: "플리7", titleImageUrl: "https://i.ytimg.com/vi/UfBxMDp7VTo/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLCJF-TybRxbbgYlWXiz2ARY6e-aHw", likeCount: 3, isPublic: false},
+    // {id: 8, title: "플리8", titleImageUrl: "https://i.ytimg.com/vi/MzVRL5W4b1I/hqdefault.jpg?s…AFwAcABBg==&rs=AOn4CLDJ-2oHWJdsOn-YBOi9t52n0qepNw", likeCount: 3, isPublic: true}
   ]);
-  const [totalPPage, setTotalPPage] = useState(1);
+  const [totalPPage, setTotalPPage] = useState(0);
   const [plysPage, setPlysPage] = useState(0);
   const [comments1, setComments1] = useState([
-    {boardId: 1, boardType: "video", content: "댓글 내용 asdfawerjwaiefjad, vndsvasdfwefsafdafdfdaf", boardTitle: "게시글 제목", createdTime: [2023,1,14,23,50,12,323453]},
-    {boardId: 1, boardType: "video", content: "댓글 내용", boardTitle: "게시글 제목", createdTime: [2023,1,14,23,50,12,323453]},
-    {boardId: 1, boardType: "video", content: "댓글 내용", boardTitle: "게시글 제목", createdTime: [2023,1,14,23,50,12,323453]},
-    {boardId: 1, boardType: "video", content: "댓글 내용", boardTitle: "게시글 제목", createdTime: [2023,1,14,23,50,12,323453]},
-    {boardId: 1, boardType: "video", content: "댓글 내용", boardTitle: "게시글 제목", createdTime: [2023,1,14,23,50,12,323453]},
+    // {boardId: 1, boardType: "video", content: "댓글 내용 asdfawerjwaiefjad, vndsvasdfwefsafdafdfdaf", boardTitle: "게시글 제목", createdTime: [2023,1,14,23,50,12,323453]},
+    // {boardId: 1, boardType: "video", content: "댓글 내용", boardTitle: "게시글 제목", createdTime: [2023,1,14,23,50,12,323453]},
+    // {boardId: 1, boardType: "video", content: "댓글 내용", boardTitle: "게시글 제목", createdTime: [2023,1,14,23,50,12,323453]},
+    // {boardId: 1, boardType: "video", content: "댓글 내용", boardTitle: "게시글 제목", createdTime: [2023,1,14,23,50,12,323453]},
+    // {boardId: 1, boardType: "video", content: "댓글 내용", boardTitle: "게시글 제목", createdTime: [2023,1,14,23,50,12,323453]},
   ]);
-  const [totalCPage, setTotalCPage] = useState(3);
-  const [commentsPage, setcommentsPage] = useState(0);
   const [comments2, setComments2] = useState([
-    {boardId: 1, boardType: "video", content: "댓글 내용", boardTitle: "게시글 제목", createdTime: [2023,1,14,23,50,12,323453]},
-    {boardId: 1, boardType: "video", content: "댓글 내용", boardTitle: "게시글 제목", createdTime: [2023,1,14,23,50,12,323453]},
-    {boardId: 1, boardType: "video", content: "댓글 내용", boardTitle: "게시글 제목", createdTime: [2023,1,14,23,50,12,323453]},
-    {boardId: 1, boardType: "video", content: "댓글 내용", boardTitle: "게시글 제목", createdTime: [2023,1,14,23,50,12,323453]},
-    {boardId: 1, boardType: "video", content: "댓글 내용", boardTitle: "게시글 제목", createdTime: [2023,1,14,23,50,12,323453]}
+    // {boardId: 1, boardType: "video", content: "댓글 내용", boardTitle: "게시글 제목", createdTime: [2023,1,14,23,50,12,323453]},
+    // {boardId: 1, boardType: "video", content: "댓글 내용", boardTitle: "게시글 제목", createdTime: [2023,1,14,23,50,12,323453]},
+    // {boardId: 1, boardType: "video", content: "댓글 내용", boardTitle: "게시글 제목", createdTime: [2023,1,14,23,50,12,323453]},
+    // {boardId: 1, boardType: "video", content: "댓글 내용", boardTitle: "게시글 제목", createdTime: [2023,1,14,23,50,12,323453]},
+    // {boardId: 1, boardType: "video", content: "댓글 내용", boardTitle: "게시글 제목", createdTime: [2023,1,14,23,50,12,323453]}
   ]);
+  const [totalCPage, setTotalCPage] = useState(0);
+  const [commentsPage, setcommentsPage] = useState(0);
+
+
+  // 게시한 영상 목록 불러오기
+  useEffect(() => {
+    axios
+        .get(preURL + `/user/${user.id}/videos?page=${videosPage}`,{
+          headers: {
+            ITTASEKKI: token
+          }
+        })
+        .then((res) => {
+          console.log("👍게시한 영상 목록 불러오기 성공", res);
+          setTotalVPage(res.data['totalPageCount']);
+          setVideos(res.data['data']);
+        })
+        .catch((err) => {
+          console.log("🧨게시한 영상 목록 불러오기 실패", err);
+        })
+  },[user, videosPage]);
+
+  // 게시한 플리 목록 불러오기
+  useEffect(() => {
+    axios
+        .get(preURL + `/user/${user.id}/playlists?page=${plysPage}`,{
+          headers: {
+            ITTASEKKI: token
+          }
+        })
+        .then((res) => {
+          console.log("👍게시한 플리 목록 불러오기 성공", res);
+          setTotalPPage(res.data['totalPageCount']);
+          setPlaylist(res.data['data']);
+        })
+        .catch((err) => {
+          console.log("🧨게시한 플리 목록 불러오기 실패", err);
+          if(err.status === 403) {
+            alert('로그인 후 이용해주세요.');
+            window.location.replace("/");
+          }
+        })
+  },[user, plysPage]);
+
+  // 게시한 댓글 목록 요청
+  useEffect(() => {
+    axios
+        .get(preURL + `/user/${user.id}/comments?page=${commentsPage}`,{
+          headers: {
+            ITTASEKKI: token
+          }
+        })
+        .then((res) => {
+          console.log("👍게시한 댓글 목록 불러오기 성공", res);
+          setTotalCPage(res.data['totalPageCount']);
+          // 댓글 5개씩
+          const Data = res.data['data'];
+          let list1 = [], list2 = [];
+          for(let i=0; i<Data.length; i++) {
+            if(i<5) list1.push(Data[i]);
+            else list2.push(Data[i]);
+          }
+          setComments1(list1);
+          setComments2(list2);
+        })
+        .catch((err) => {
+          console.log("🧨게시한 댓글 목록 불러오기 실패", err);
+        })
+  },[user, videosPage]);
 
 
   return (
@@ -120,12 +194,12 @@ const MyPage = () => {
               <StyledDivRow>
                 <Comments>
                   {comments1.map((comment) => {
-                    return <p>{comment.content}</p>
+                    return <MyComment comment={comment} />
                   })}
                 </Comments>
                 <Comments>
                   {comments2.map((comment) => {
-                    return <p>{comment.content}</p>
+                    return <MyComment comment={comment} />
                   })}
                 </Comments>
               </StyledDivRow>

--- a/src/Pages/Member/MySavedPly.js
+++ b/src/Pages/Member/MySavedPly.js
@@ -1,6 +1,9 @@
-import React, {useState} from "react";
+import React, {useContext, useEffect, useState} from "react";
 import {useNavigate} from "react-router-dom";
+import {UserContext} from "../../_contextAPI/UserContext";
+import {preURL} from "../../preURL/preURL";
 // Component
+import Token from "../../Components/Token";
 import Header from "../../Components/Header";
 import MyPly from "../../Components/Mypage/MyPly";
 import Pagination from "../../Components/Mypage/Pagination";
@@ -11,23 +14,50 @@ import {VideoList} from "../../Style/Video";
 // Assets
 import GoSetting from "../../Assets/Mypage_GotoSetting.png";
 import Eye from "../../Assets/Mypage_eye2.png";
+import axios from "axios";
 
 
 const MySavedPly = () => {
   const navigate = useNavigate();
+  const token = Token();
+  const [user, setUser] = useContext(UserContext);
 
-  const [totalPage, setTotalPage] = useState(2);
+  const [totalPage, setTotalPage] = useState(0);
   const [page, setPage] = useState(0);
   const [playlist, setPlaylist] = useState([
-    {id: 1, title: "플리1", titleImageUrl: "https://i.ytimg.com/vi/xhyWDLWanHE/hqdefault.jpg?s…AFwAcABBg==&rs=AOn4CLDNC541Gll7yxMs9Vcc8MWtC9gzLg", likeCount: 3, isPublic: null},
-    {id: 2, title: "플리2", titleImageUrl: "https://i.ytimg.com/vi/MRaAcIQOIIw/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLDMAXcYHT37gxseIf6CA94ICpnTuQ", likeCount: 25, isPublic: null},
-    {id: 3, title: "플리3", titleImageUrl: "https://i.ytimg.com/vi/1ktnYFMm4S0/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLBRJHJTM-_VzaapK9oCWlD8t-K8WQ", likeCount: 3, isPublic: null},
-    {id: 4, title: "플리4", titleImageUrl: "https://i.ytimg.com/vi/Q2ehBSEkAzw/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLDgtPhu8WY4xOABtcCjVo5x-hgswA", likeCount: 22, isPublic: null},
-    {id: 5, title: "플리5", titleImageUrl: "https://i.ytimg.com/vi/mKkYQ2OwYYg/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLB-2wmECn5003TmXqION-Nqcgahzw", likeCount: 30, isPublic: null},
-    {id: 6, title: "플리6", titleImageUrl: "https://i.ytimg.com/vi/iiIcTPoIoZk/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLAjn_R-euhMSNKaCFjJzO89A93tAA", likeCount: 19, isPublic: null},
-    {id: 7, title: "플리7", titleImageUrl: "https://i.ytimg.com/vi/UfBxMDp7VTo/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLCJF-TybRxbbgYlWXiz2ARY6e-aHw", likeCount: 3, isPublic: null},
-    {id: 8, title: "플리8", titleImageUrl: "https://i.ytimg.com/vi/MzVRL5W4b1I/hqdefault.jpg?s…AFwAcABBg==&rs=AOn4CLDJ-2oHWJdsOn-YBOi9t52n0qepNw", likeCount: 3, isPublic: null}
+    // {id: 1, title: "플리1", titleImageUrl: "https://i.ytimg.com/vi/xhyWDLWanHE/hqdefault.jpg?s…AFwAcABBg==&rs=AOn4CLDNC541Gll7yxMs9Vcc8MWtC9gzLg", likeCount: 3, isPublic: null},
+    // {id: 2, title: "플리2", titleImageUrl: "https://i.ytimg.com/vi/MRaAcIQOIIw/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLDMAXcYHT37gxseIf6CA94ICpnTuQ", likeCount: 25, isPublic: null},
+    // {id: 3, title: "플리3", titleImageUrl: "https://i.ytimg.com/vi/1ktnYFMm4S0/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLBRJHJTM-_VzaapK9oCWlD8t-K8WQ", likeCount: 3, isPublic: null},
+    // {id: 4, title: "플리4", titleImageUrl: "https://i.ytimg.com/vi/Q2ehBSEkAzw/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLDgtPhu8WY4xOABtcCjVo5x-hgswA", likeCount: 22, isPublic: null},
+    // {id: 5, title: "플리5", titleImageUrl: "https://i.ytimg.com/vi/mKkYQ2OwYYg/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLB-2wmECn5003TmXqION-Nqcgahzw", likeCount: 30, isPublic: null},
+    // {id: 6, title: "플리6", titleImageUrl: "https://i.ytimg.com/vi/iiIcTPoIoZk/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLAjn_R-euhMSNKaCFjJzO89A93tAA", likeCount: 19, isPublic: null},
+    // {id: 7, title: "플리7", titleImageUrl: "https://i.ytimg.com/vi/UfBxMDp7VTo/hq720.jpg?sqp=-…AFwAcABBg==&rs=AOn4CLCJF-TybRxbbgYlWXiz2ARY6e-aHw", likeCount: 3, isPublic: null},
+    // {id: 8, title: "플리8", titleImageUrl: "https://i.ytimg.com/vi/MzVRL5W4b1I/hqdefault.jpg?s…AFwAcABBg==&rs=AOn4CLDJ-2oHWJdsOn-YBOi9t52n0qepNw", likeCount: 3, isPublic: null}
   ]);
+
+
+  // 저장한 플레이리스트 목록 받아오기
+  useEffect(() => {
+    axios
+        .get(preURL + `/user/${user.id}/playlists/?page=${page}&type=saved&size=40`,{
+          headers: {
+            ITTASEKKI: token
+          }
+        })
+        .then((res) => {
+          console.log("👍저장한 플레이리스트 목록 불러오기 성공", res);
+          setTotalPage(res.data['totalPageCount']);
+          setPlaylist(res.data['data']);
+        })
+        .catch((err) => {
+          console.log("🧨저장한 플레이리스트 목록 불러오기 실패", err);
+          if(err.status === 403) {
+            alert('로그인 후 이용해주세요.');
+            window.location.replace("/");
+          }
+        })
+  },[user, page]);
+
 
   return (
       <>


### PR DESCRIPTION
## feat/mypage -> main✨

## 구현 내용✏
- 마이페이지 나의 게시물(게시한 영상, 플리, 댓글), 저장한 플리 목록 요청
- 마이페이지 댓글 컴포넌트 생성
- 전체 영상 페이지 url 변경: /videolist -> /video

## 구현 결과 화면🎨


## 유의사항🧨
- 마이페이지에서 프로필 관련 기능 아직X (프로필 조회, 수정 및 탈퇴 기능)